### PR TITLE
Fix ansible error when installing kubernetes binary

### DIFF
--- a/hands-on/vagrant/roles/general/tasks/01-install.yml
+++ b/hands-on/vagrant/roles/general/tasks/01-install.yml
@@ -76,6 +76,7 @@
   apt: 
     name: "{{ item }}={{ k8s_version }}-00"
     state: present
+    force: True
     update_cache: yes
   with_items:
     - kubelet


### PR DESCRIPTION
Signed-off-by: zufardhiyaulhaq <zufardhiyaulhaq@gmail.com>

Previously, when I try to run `vagrant up` and got this error
```
TASK [general : Install Kubernetes binaries] ***********************************
Saturday 13 November 2021  11:31:40 +0100 (0:00:03.910)       0:02:28.164 *****
changed: [master] => (item=kubelet)
changed: [master] => (item=kubeadm)
failed: [master] (item=kubectl) => {"ansible_loop_var": "item", "cache_update_time": 1636799515, "cache_updated": true, "changed": false, "item": "kubectl", "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'kubectl=1.19.1-00'' failed: E: Packages were downgraded and -y was used without --allow-downgrades.\n", "rc": 100, "stderr": "E: Packages were downgraded and -y was used without --allow-downgrades.\n", "stderr_lines": ["E: Packages were downgraded and -y was used without --allow-downgrades."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages will be DOWNGRADED:\n  kubectl\n0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 2 not upgraded.\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following packages will be DOWNGRADED:", "  kubectl", "0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 2 not upgraded."]}
```

This MR fix the error by adding `force: True`.